### PR TITLE
Drop code-font on "Cloud Tools for PowerShell"

### DIFF
--- a/website/content/home.html
+++ b/website/content/home.html
@@ -59,13 +59,13 @@
     <div class="quote-box">
       <h3 class="block-title">What is it?</h3>
 
-      <p><code>Cloud Tools for PowerShell</code> is a set of PowerShell
+      <p><strong>Cloud Tools for PowerShell</strong> is a set of PowerShell
       cmdlets for accessing and manipulating Google Cloud Platform
       resources. With them you will be able to automate tasks by writing
       programs in PowerShell. And ultimately get more done on the
       Google Cloud Platform.</p>
 
-      <p><code>Cloud Tools for PowerShell</code> uses the same configuration
+      <p>Cloud Tools for PowerShell uses the same configuration
       and credentials used by the Google Cloud SDK (<code>gcloud</code>).
       Once you authenticate (<code>gcloud auth login</code>) you will be
       able to use PowerShell cmdlets.</p>
@@ -149,14 +149,14 @@ $newZone = Get-GcdManagedZone -Zone "my-new-zone"
     <div class="container clearfix">
     <h3 class="block-title">FAQ</h3>
 
-    <h4>What is the relationship between the <code>Cloud Tools for PowerShell</code>
+    <h4>What is the relationship between the Cloud Tools for PowerShell
     and the <code>gcloud</code> command-line tool?</h4>
 
-    <p>Both the <code>gcloud</code> command-line tool and <code>Cloud Tools for PowerShell</code>
+    <p>Both the <code>gcloud</code> command-line tool and Cloud Tools for PowerShell
     cmdlets allow you to manage your cloud resources. However, the
-    <code>Cloud Tools for PowerShell</code> returns strongly-typed objects rather than
-    plain text. So cmdlet results can be latter transformed within Windows PowerShell.
-    With <code>Cloud Tools for PowerShell</code> you can benefit from things like tab-completion,
+    Cloud Tools for PowerShell cmdlets return strongly-typed objects rather than
+    plain text, so that results can be more easily manipulated within Windows PowerShell.
+    With Cloud Tools for PowerShell you can benefit from things like tab-completion,
     type checking, and integrated help.</p>
     </div>
 </section> <!-- end of FAQ -->


### PR DESCRIPTION
Especially with three full-fixed-width spaces in the name, putting it in `<code>` looks totally awkward. In any case, `<code>` should be reserved for things you will actually type at the command line, which you never do with "Cloud Tools for PowerShell", unlike `gcloud` or even `Add-GcdManagedZone`.

Also rewords text with an incorrect use of "latter" in the last paragraph. It seems "later" was meant, but even then it was in need of  more extensive restructuring for English grammar and clarity.